### PR TITLE
Fix C++17 does not allow register storage class specifier

### DIFF
--- a/src/Inventor/Xt/widgets/SoXtGLArea.cpp
+++ b/src/Inventor/Xt/widgets/SoXtGLArea.cpp
@@ -468,7 +468,7 @@ createColormap(
   } * cmapCache;
   static int cacheEntries = 0;
   static int cacheMalloced = 0;
-  register int i;
+  int i;
     
   assert(widget->soxtGLArea.visualInfo);
 
@@ -564,7 +564,7 @@ Realize(
   Mask * valueMask,
   XSetWindowAttributes * attributes)
 {
-  register SoXtGLAreaWidget glw = (SoXtGLAreaWidget) widget;
+  SoXtGLAreaWidget glw = (SoXtGLAreaWidget) widget;
   SoXtGLAreaCallbackStruct cb;
   Widget parentShell;
   Status status;
@@ -670,7 +670,7 @@ Destroy(
   Widget parentShell;
   Status status;
   int countReturn;
-  register int i;
+  int i;
 
   if (glw->soxtGLArea.myList && glw->soxtGLArea.attribList)
     XtFree((char *) glw->soxtGLArea.attribList);


### PR DESCRIPTION
The register storage class was deprecated in C++14 and completely removed in C++17. Hence, we cannot use it anymore and would result in a build error.